### PR TITLE
Explicitly pass SQL Server connection string in Web Jobs

### DIFF
--- a/src/PartsUnlimited.Models/PartsUnlimitedContext.cs
+++ b/src/PartsUnlimited.Models/PartsUnlimitedContext.cs
@@ -8,6 +8,17 @@ namespace PartsUnlimited.Models
 {
     public class PartsUnlimitedContext : IdentityDbContext<ApplicationUser>, IPartsUnlimitedContext
     {
+        private readonly string _connectionString;
+
+        public PartsUnlimitedContext()
+        {
+        }
+
+        public PartsUnlimitedContext(string connectionString)
+        {
+            _connectionString = connectionString;
+        }
+
         public DbSet<Product> Products { get; set; }
         public DbSet<Order> Orders { get; set; }
         public DbSet<Category> Categories { get; set; }
@@ -27,6 +38,14 @@ namespace PartsUnlimited.Models
             builder.Entity<Store>().Key(o => o.StoreId);
 
             base.OnModelCreating(builder);
+        }
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        {
+            if (!string.IsNullOrWhiteSpace(_connectionString))
+            {
+                optionsBuilder.UseSqlServer(_connectionString);
+            }
         }
     }
 }

--- a/src/PartsUnlimited.WebJobs.ProcessOrder/Functions.cs
+++ b/src/PartsUnlimited.WebJobs.ProcessOrder/Functions.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Linq;
 using Microsoft.Azure.WebJobs;
+using Microsoft.Framework.ConfigurationModel;
 using Microsoft.WindowsAzure.Storage.Queue;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
@@ -19,7 +20,10 @@ namespace PartsUnlimited.WebJobs.ProcessOrder
             Console.WriteLine("Starting Create Order Process Task");
             try
             {
-                using (var context = new PartsUnlimitedContext())
+                var config = new Configuration().AddJsonFile("config.json");
+                var connectionString = config.Get("Data:DefaultConnection:ConnectionString");
+
+                using (var context = new PartsUnlimitedContext(connectionString))
                 {
                     var orders = context.Orders.Where(x => !x.Processed).ToList();
                     Console.WriteLine("Found {0} orders to process", orders.Count);

--- a/src/PartsUnlimited.WebJobs.UpdateProductInventory/Functions.cs
+++ b/src/PartsUnlimited.WebJobs.UpdateProductInventory/Functions.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs;
+using Microsoft.Framework.ConfigurationModel;
 using PartsUnlimited.Models;
 
 namespace PartsUnlimited.WebJobs.UpdateProductInventory
@@ -13,7 +14,10 @@ namespace PartsUnlimited.WebJobs.UpdateProductInventory
     {
         public async static Task UpdateProductProcessTaskAsync([QueueTrigger("product")] ProductMessage message)
         {
-            using (var context = new PartsUnlimitedContext())
+            var config = new Configuration().AddJsonFile("config.json");
+            var connectionString = config.Get("Data:DefaultConnection:ConnectionString");
+
+            using (var context = new PartsUnlimitedContext(connectionString))
             {
                 var dbProductList = await context.Products.ToListAsync();
                 foreach (var queueProduct in message.ProductList)


### PR DESCRIPTION
Web Jobs don't use dependency injection so the connection string needs to be manually applied to the DbContext. Refer [here](https://github.com/aspnet/EntityFramework/wiki/Configuring-a-DbContext) for more details.