### PR TITLE
Replace hard-coded path C:\Agent\HOL with $(build.artifactstagingdire…

### DIFF
--- a/docs/HOL_PartsUnlimited_WebSite_Continuous_Integration/HOL_PartsUnlimited_WebSite_Continuous_Integration_with_Visual_Studio_Online_Build.md
+++ b/docs/HOL_PartsUnlimited_WebSite_Continuous_Integration/HOL_PartsUnlimited_WebSite_Continuous_Integration_with_Visual_Studio_Online_Build.md
@@ -140,7 +140,7 @@ PartsUnlimited source is in.
     
     /p:SkipInvalidConfigurations=true 
     
-    /p:PackageLocation="C:\Agent\HOL"
+    /p:PackageLocation=$(build.artifactstagingdirectory) 
 
 ![](<media/48.jpg>)
 
@@ -161,7 +161,7 @@ PartsUnlimited source is in.
 **11.** Select the **Publish Build Artifacts** task, and fill in the input values
 with the following:
 
-	Copy Root: C:/Agent/HOL
+	Copy Root: $(build.artifactstagingdirectory) 
 	Contents: *.zip
 	Artifact Name: drop
 	Artifact Type: Server


### PR DESCRIPTION
…ctory)

Would it not be preferred to not use a hard-coded path but use the variable for the staging folder?   I completed the CI LAB using VSTS and the Hosted Agent.