### PR TITLE
Fixed item detail's always displaying price in USD

### DIFF
--- a/src/PartsUnlimitedWebsite/Views/Store/Details.cshtml
+++ b/src/PartsUnlimitedWebsite/Views/Store/Details.cshtml
@@ -32,7 +32,7 @@
             </div>
             <div class="col-md-8">
                     <div>
-                        <h5>USD $@Model.Price</h5>
+                        <h5>@Model.Price.ToString("C")</h5>
                     </div>
                     <div>
                             @if (@Model.Inventory > 0)


### PR DESCRIPTION
- The product Details view was hard coded to display USD, where as the other product
  views showed a local currency symbol. This is a simple fix to make it
  consistent formatting.

 #65