### PR TITLE
Updating the location of the publish script

### DIFF
--- a/scripts/PublishWebsite.ps1
+++ b/scripts/PublishWebsite.ps1
@@ -1,0 +1,16 @@
+ param($websiteName, $packOutput)
+ $website = Get-AzureWebsite -Name $websiteName
+
+ # get the SCM URL to use with MSDeploy.  
+ # by default this will be the second in the array.
+ $msdeployurl = $website.EnabledHostNames[1]
+
+ $publishProperties = @{'WebPublishMethod'='MSDeploy';
+                 'MSDeployServiceUrl'=$msdeployurl;
+                 'DeployIisAppPath'=$website.Name;
+                 'Username'=$website.PublishingUsername;
+                 'Password'=$website.PublishingPassword}
+
+ $publishScript = "${env:ProgramFiles(x86)}\Microsoft Visual Studio 14.0\Common7\IDE\Extensions\Microsoft\Web Tools\Publish\Scripts\default-publish.ps1"
+
+ . $publishScript -publishProperties $publishProperties  -packOutput $packOutput


### PR DESCRIPTION
The VSTS hosted image updated Visual Studio and the location of the default-publish.ps1 moved up a folder. This was causing the deploy script in the Release Management definition to fail. This PR updates our script to use the new location of that script. 
Have tested with my fork already to ensure the update works.
![screen shot 2016-06-17 at 8 36 46 am](https://cloud.githubusercontent.com/assets/1563288/16155956/a959de8c-3466-11e6-8c8e-bb6e45831907.png)
