### PR TITLE
update connection string to DB

### DIFF
--- a/src/PartsUnlimitedWebsite/Web.config
+++ b/src/PartsUnlimitedWebsite/Web.config
@@ -20,7 +20,7 @@
     <add key="MachineLearning.AccountKey" value="" />
   </appSettings>
   <connectionStrings>
-    <add name="DefaultConnectionString" connectionString="Server=(localdb)\v11.0;Database=PartsUnlimitedWebsite;Integrated Security=True;" providerName="System.Data.SqlClient" />
+    <add name="DefaultConnectionString" connectionString="Server=(local)\SQLExpress;Database=PartsUnlimitedWebsite;Integrated Security=True;" providerName="System.Data.SqlClient" />
   </connectionStrings>
   <system.web>
     <customErrors mode="Off" />


### PR DESCRIPTION
@dtzar With this connection string it is working fine on SQL Express 2014, and I believe it should work with any version of Express as well (not tested).
I believe what we have currently doesn't work with SQL 2012 Express either... only LocalDB 2012.

This new connection string won't work with other versions of SQL (LocalDB 2014 and full editions).  
I'll take some time to add documentation in the `GetStarted` so that people install the correct version of SQL. 
