### PR TITLE
Updated Application Insights location to East US

### DIFF
--- a/env/Templates/AppInsights.json
+++ b/env/Templates/AppInsights.json
@@ -10,7 +10,7 @@
         {
             "name": "[concat(parameters('WebsiteName'), 'Insights')]",
             "type": "Microsoft.Insights/components",
-            "location": "Central US",
+            "location": "East US",
             "apiVersion": "2014-04-01",
             "tags": {
                 "displayName": "insightsComponents"

--- a/env/Templates/FullEnvironmentSetupMerged.json
+++ b/env/Templates/FullEnvironmentSetupMerged.json
@@ -225,7 +225,7 @@
     {
       "name": "[concat(parameters('WebsiteName'), '-Insights')]",
       "type": "Microsoft.Insights/components",
-      "location": "Central US",
+      "location": "East US",
       "apiVersion": "2014-04-01",
       "tags": {
         "displayName": "insightsComponents"
@@ -237,7 +237,7 @@
     {
       "name": "[concat(parameters('WebsiteName'), '-DevInsights')]",
       "type": "Microsoft.Insights/components",
-      "location": "Central US",
+      "location": "East US",
       "apiVersion": "2014-04-01",
       "tags": {
         "displayName": "insightsComponents"
@@ -249,7 +249,7 @@
     {
       "name": "[concat(parameters('WebsiteName'), '-StagingInsights')]",
       "type": "Microsoft.Insights/components",
-      "location": "Central US",
+      "location": "East US",
       "apiVersion": "2014-04-01",
       "tags": {
         "displayName": "insightsComponents"


### PR DESCRIPTION
Fixes "The subscription is not registered for the resource type 'components' in the location 'centralus'.
Please re-register for this provider in order to have access to this location.  (Code: MissingRegistrationForLocation)" when deploying ARM resources.

[Application Insights resource location update](https://azure.microsoft.com/en-us/updates/application-insights-general-availability-in-additional-regions-and-resource-location-update-east-us-south-central-us-west-europe-and-north-europe/)