### PR TITLE
Please correct Provision-lab-textual-workflow

### DIFF
--- a/Labfiles/Devops200.2x-InfrastructureasCode/Mod01/Provision-lab-textual-workflow-v1.ps1
+++ b/Labfiles/Devops200.2x-InfrastructureasCode/Mod01/Provision-lab-textual-workflow-v1.ps1
@@ -113,8 +113,7 @@ Parallel
  
     $vm2 = Set-AzureRmVMOperatingSystem -VM $vm2 -Windows -ComputerName $using:vm2Name -Credential $using:credentials -ProvisionVMAgent EnableAutoUpdate 
     $vm2 = Set-AzureRmVMSourceImage -VM $vm2 -PublisherName $using:publisherName -Offer $using:offer -Skus $using:sku -Version $using:version 
-    $vm2 = Set-AzureRmVMOSDisk -VM $vm2 -Name $using:vm2osDiskName -StorageAccountType StandardLRS -DiskSizeInGB $using:vmosDiskSize -CreateOption fromImage -Caching ReadWrite 
- 
+
    $blobPath2 = 'vhds/' + $using:vm2osDiskName + '.vhd' 
    $osDiskUri2 = $storageAccount2.PrimaryEndpoints.Blob.ToString() + $blobPath2 
    $vm2 = Set-AzureRmVMOSDisk -VM $vm2 -Name $using:vm2osDiskName -VhdUri $osDiskUri2 -CreateOption fromImage 


### PR DESCRIPTION
Please remove string number 116 that states as 


  $vm2 = Set-AzureRmVMOSDisk -VM $vm2 -Name $using:vm2osDiskName -StorageAccountType StandardLRS -DiskSizeInGB $using:vmosDiskSize -CreateOption fromImage -Caching ReadWrite 


We have Set-AzureRmVMOSDisk executed 2 times for second vm. First VM creates successfully without error, but when we creating second vm script generates an error.
If string 116 exist, script complete with error " New-AzureRmVM : Parameter 'osDisk.managedDisk' is not allowed."
Just remove this string and script will execute without error.