### PR TITLE
Chance "Save" to "Commit..." for VSTS Editor

### DIFF
--- a/docs/HOL-Continuous_Integration/README.md
+++ b/docs/HOL-Continuous_Integration/README.md
@@ -196,7 +196,7 @@ We will now test the **Continuous Integration build (CI)** build we created by c
 
 ![](<media/CI15.png>)
 
-**2.** After clicking **Edit**, add in text (i.e. *This is a test of CI*) after the last *Using* statement. Once complete, click **Save**.
+**2.** After clicking **Edit**, add in text (i.e. *This is a test of CI*) after the last *Using* statement. Once complete, click **Commit...**.
 
 ![](<media/CI16.png>)
 


### PR DESCRIPTION
The button to commit changes in the VSTS online editor (the picture of the floppy disk) is now labelled "Commit..." rather than save.

The graphic in this section of text has been updated to use the new label "Commit", but the accompanying text has not. The graphic linked here is not the same as the one in the HOL website.

(I fear there may come a time when the average VSTS user has no idea what a floppy disk was.)