### PR TITLE
Update 2018-01-08-200.3x-CICD-CDwithOctopus.md

### DIFF
--- a/_posts/2018-01-08-200.3x-CICD-CDwithOctopus.md
+++ b/_posts/2018-01-08-200.3x-CICD-CDwithOctopus.md
@@ -348,7 +348,7 @@ We are going to create a simple ASP.NET using Visual Studio 2017; it is enough f
 11. Click on _Push Packages to Octopus_ task and enter the following values:
 
     * The connected service name we configured previously in the **Octopus Deploy Server** drop-down
-    * $(Build.ArtifactStagingDirectory)\packages\*.nupkg for **Package**
+    * $(Build.ArtifactStagingDirectory)\packages\\*.nupkg for **Package**
 
     ![Screenshot of the Push Package(s) to Octopus dialog box. The Display name is “Push Packages to Octopus.” The Octopus Deploy Server field is circled, and is set to Octopus Deploy, and the Package field is with the previously mentioned parameter, and is circled.](../assets/octopus-jan2018/config_build_push_parameters.png)
 


### PR DESCRIPTION
Task 5 - Step 11 wasn't escaping the \ so the path to enter was wrong if you were copying and pasting.