### PR TITLE
Remove `docker stop <imagename>`

### DIFF
--- a/_posts/2018-01-08-200.4x-ConfigMgmt-WorkingwithContainers.md
+++ b/_posts/2018-01-08-200.4x-ConfigMgmt-WorkingwithContainers.md
@@ -571,9 +571,6 @@ We will quickly scale out our container web sites, to demonstrate how quickly it
 2. Return to the web browser and refresh it, and verify the container web pages are no longer available.
 
 
-    ```
-    docker stop <image name>. 
-    ```
 
     ![Docker contianer run](../assets/workingwithcontainers-jan2018\dockerrunscale5.png)
 


### PR DESCRIPTION
As above, you can't stop an image, only a container. I don't think this is required here anyway, the previous step stops the images and the next step tells the user to use the browser to verify that the sites have gone.