### PR TITLE
Remove --password argument from CI CD with DevOps

### DIFF
--- a/_posts/2018-01-08-200.1x-PandP-CICDQuickstartwithVSTS.md
+++ b/_posts/2018-01-08-200.1x-PandP-CICDQuickstartwithVSTS.md
@@ -153,7 +153,7 @@ In this lab, we will use a **Service Principal** and add these details to a **Se
 3. Create a SP by running the following command. The output displayed will be similar to the screenshot below.
 
 	```
-	az ad sp create-for-rbac --name PU1app --password Pa$$w0rd01
+	az ad sp create-for-rbac --name PU1app
 	```
 
 	![](../assets/cicdquickstart-jan2018/SPN1.png)


### PR DESCRIPTION
Request to remove depreciated `--password` argument from **Task 3.3** of **CI CD with DevOps lab** to resolve issue #184 

**Task 3.3** of the [CI and CD with Azure DevOps - Quickstart lab](https://microsoft.github.io/PartsUnlimited/pandp/200.1x-PandP-CICDQuickstartwithVSTS.html) instructs the learner to pass a depreciated `--password` argument when creating a new service principle. Following these instructions will cause an error, as reported in issue #184 

The depreciated `--password` argument has been removed from the modified markdown file for the lab, as part of this pull request. You can read about the depreciated `--password` argument on the [Azure CLI Documentation](https://docs.microsoft.com/en-us/cli/azure/create-an-azure-service-principal-azure-cli?view=azure-cli-latest#password-based-authentication) pages.