### PR TITLE
updated location of azure-vote-front container image

### DIFF
--- a/Labfiles/AZ-400T05_Implementing_Application_Infrastructure/M03/azure-vote.yaml
+++ b/Labfiles/AZ-400T05_Implementing_Application_Infrastructure/M03/azure-vote.yaml
@@ -52,7 +52,7 @@ spec:
     spec:
       containers:
       - name: azure-vote-front
-        image: microsoft/azure-vote-front:v1
+        image: mcr.microsoft.com/azuredocs/azure-vote-front:v1
         resources:
           requests:
             cpu: 100m


### PR DESCRIPTION
Pulling image `microsoft/azure-vote-front` no longer works, and leaves pods in `ErrImagePull` status.
The image has been moved to `mcr.microsoft.com/azuredocs/azure-vote-front`, so updating the manifest to reflect this.
Relevant on [Task 4 of Deploy Application to Azure Kubernetes Service](https://microsoft.github.io/PartsUnlimited/iac/200.2x-IaCDeployApptoAKS.html#task-4-create-sample-application-and-deploy-it-to-the-aks-cluster) lab.