### PR TITLE
Update Fork me on GitHub image source

### DIFF
--- a/src/PartsUnlimitedWebsite/Views/Home/Index.cshtml
+++ b/src/PartsUnlimitedWebsite/Views/Home/Index.cshtml
@@ -103,7 +103,7 @@
     }
 
 <a href="https://github.com/Microsoft/PartsUnlimited" target="_blank" class="hidden-xs">
-    <img style="position: absolute; top: 0; left: 0; border: 0;" src="https://camo.githubusercontent.com/c6625ac1f3ee0a12250227cf83ce904423abf351/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f6c6566745f677261795f3664366436642e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_left_gray_6d6d6d.png">
+    <img style="position: absolute; top: 0; left: 0; border: 0;" src="https://github.blog/wp-content/uploads/2008/12/forkme_left_gray_6d6d6d.png?resize=149%2C149" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_left_gray_6d6d6d.png">
 </a>
 <div id="home-page">
     <section class="section-alt">


### PR DESCRIPTION
### Summary of the changes
 - This pull request amends the "Fork me on GitHub" image source to reflect the guidelines outlined in the GitHub blog post [here](https://github.blog/2008-12-19-github-ribbons/).
 
### Related Issue
This pull request is related to issue #[285](https://github.com/microsoft/PartsUnlimited/issues/285).
